### PR TITLE
Removing dom ID requirement for margin/sidenotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Mathjax renders LaTeX written inside of markdown files.  LaTeX can be
 written more or less as normal, but inline and display environments that
 start with `\` must be escaped.  Some examples:
 
-- `This $\LaTeX$ will be rendered inline.` 
-- `This \\(\LaTeX\\) will be rendered inline.` 
+- `This $\LaTeX$ will be rendered inline.`
+- `This \\(\LaTeX\\) will be rendered inline.`
 - `A simple displayed equation: $$f(x, y) := e^{x^2 - y^2}.$$`
 - `A simple displayed equation: \\[f(x, y) := e^{x^2 - y^2}.\\]`
 
@@ -53,7 +53,7 @@ The site specific parameters that this theme recognizes are:
   true, `hideDate` takes greater precedence.
 - `hideReadTime` boolean: if true, do not display the page's reading time
   estimate.  When `meta` is set to true, `hideReadTime` takes greater precedence.
-- `math` boolean: if true, try to render the page's LaTeX code using MatheJax. 
+- `math` boolean: if true, try to render the page's LaTeX code using MatheJax.
 - `meta` boolean: if true, display page metadata such as author, date, categories provided
   these page parameters exist and are not overridden.  Content in the `/post` directory,
   (i.e., pages of type "post") ignore this parameter.
@@ -62,17 +62,17 @@ The site specific parameters that this theme recognizes are:
 ## Shortcodes
 
 This theme provides the following shortcodes in an attempt to completely
-support all the features present in the 
+support all the features present in the
 [Tufte-css](https://github.com/edwardtufte/tufte-css) project.
 
 - `blockquote`
   - **Description**: Wrap text in a blockquote and insert optional
   `cite` or `footer` metadata.
   - **Usage**: Accepts the named parameters `cite` and `footer`.
-  - **Example**: 
+  - **Example**:
   ```html
   {{% blockquote cite="www.shawnohare.com" footer="Shawn" %}}
-    There is nothing more beautiful than an elegant mathematical proof. 
+    There is nothing more beautiful than an elegant mathematical proof.
   {{% /blockquote %}}`
   ```
 
@@ -84,20 +84,20 @@ support all the features present in the
    Accepts the style parameters `class` and `id`.
    If only the positional argument `"end"` is passed, a closing tag
    will be inserted.
-   - **Example**: `{{< div class="my-class" >}}` inserts a 
+   - **Example**: `{{< div class="my-class" >}}` inserts a
    `<div class="my-class">` tag, while
    `{{<div "end" >}}` inserts the closing `</div>` tag.
 
 - `epigraph`
   - **Description**: Create an epigraph with the wrapped text.
   - **Usage**: To include a footer with source attribution, pass in the
-  optional named parameters `pre`, `cite`, `post`. These parameters 
+  optional named parameters `pre`, `cite`, `post`. These parameters
   make no styling assumptions, so spacing is important.  A more compactly
   styled epigraph will be used if the `type` parameter is set to `compact`.
   - **Example**:
   ```
   {{% epigraph pre="Author Writer, " cite="Math is Fun" %}}
-  This is an example of an epigraph with some math 
+  This is an example of an epigraph with some math
   \\( \mathbb N \subseteq \mathbb R \\)
   to start the beginning of a section.
   {{% /epigraph %}}
@@ -105,9 +105,8 @@ support all the features present in the
 
 - `marginnote`
   - **Description**: Wrap text to produce a numberless margin note.
-  - Usage: Accepts a required positional argument that is the margin note id.
-  `{{% marginnote "<margin note id>"" %}}...{{% /marginnote %}}`
-  - **Example**: `{{% marginnote "mn-example" %}}Some marginnote{{% /marginnote%}}`
+  - Usage: `{{% marginnote %}}...{{% /marginnote %}}`
+  - **Example**: `{{% marginnote %}}Some marginnote{{% /marginnote%}}`
 
 - `section`
    - **Description**: This shortcode is provided as a work-around for wrapping
@@ -116,17 +115,16 @@ support all the features present in the
    - **Usage**: Accepts the style parameters `class` and `id`.
    If only the positional argument `"end"` is passed, a closing tag
    will be inserted.
-   - **Example**: `{{< section class="my-class" >}}` inserts a 
+   - **Example**: `{{< section class="my-class" >}}` inserts a
    `<section class="my-class">` tag, while
    `{{<section "end" >}}` inserts the closing `</section>` tag.
 
 
 - `sidenote`
   - **Description**: Wrap text to produce an automatically numbered sidenote.
-  - **Usage**: identical to `marginnote`. 
-  Accepts a required positional argument that is the side note id.
-  `{{% sidenote "<side note id>"" %}}...{{% /sidenote %}}`
-  - **Example**: `{{% sidenote "sn-example" %}}Some sidenote{{% /sidenote %}}`
+  - **Usage**: identical to `marginnote`
+  `{{% sidenote %}}...{{% /sidenote %}}`
+  - **Example**: `{{% sidenote %}}Some sidenote{{% /sidenote %}}`
 
 
 ## Templates

--- a/layouts/shortcodes/marginnote.html
+++ b/layouts/shortcodes/marginnote.html
@@ -1,3 +1,9 @@
-<label for="{{ .Get 0 }}" class="margin-toggle">&#8853;</label>
-<input type="checkbox" id="{{ .Get 0 }}" class="margin-toggle"/>
+{{ $marginnoteDomIdSuffix := .Page.Scratch.Get "marginnoteDomIdSuffix" }}
+{{ if eq $marginnoteDomIdSuffix nil }}
+{{ .Page.Scratch.Set "marginnoteDomIdSuffix" 0 }}
+{{ end }}
+{{ .Page.Scratch.Add "marginnoteDomIdSuffix" 1 }}
+{{ $marginnoteDomIdSuffix = .Page.Scratch.Get "marginnoteDomIdSuffix" }}
+<label for="marginnote-{{.Page.UniqueID}}-{{ $marginnoteDomIdSuffix }}" class="margin-toggle">&#8853;</label>
+<input type="checkbox" id="marginnote-{{.Page.UniqueID}}-{{ $marginnoteDomIdSuffix }}" class="margin-toggle"/>
 <span class="marginnote">{{ .Inner }}</span>

--- a/layouts/shortcodes/marginnote.html
+++ b/layouts/shortcodes/marginnote.html
@@ -1,9 +1,3 @@
-{{ $marginnoteDomIdSuffix := .Page.Scratch.Get "marginnoteDomIdSuffix" }}
-{{ if eq $marginnoteDomIdSuffix nil }}
-{{ .Page.Scratch.Set "marginnoteDomIdSuffix" 0 }}
-{{ end }}
-{{ .Page.Scratch.Add "marginnoteDomIdSuffix" 1 }}
-{{ $marginnoteDomIdSuffix = .Page.Scratch.Get "marginnoteDomIdSuffix" }}
-<label for="marginnote-{{.Page.UniqueID}}-{{ $marginnoteDomIdSuffix }}" class="margin-toggle">&#8853;</label>
+{{ $marginnoteDomIdSuffix := .Ordinal }}<label for="marginnote-{{.Page.UniqueID}}-{{ $marginnoteDomIdSuffix }}" class="margin-toggle">&#8853;</label>
 <input type="checkbox" id="marginnote-{{.Page.UniqueID}}-{{ $marginnoteDomIdSuffix }}" class="margin-toggle"/>
 <span class="marginnote">{{ .Inner }}</span>

--- a/layouts/shortcodes/sidenote.html
+++ b/layouts/shortcodes/sidenote.html
@@ -1,9 +1,3 @@
-{{ $sidenoteDomIdSuffix := .Page.Scratch.Get "sidenoteDomIdSuffix" }}
-{{ if eq $sidenoteDomIdSuffix nil }}
-{{ .Page.Scratch.Set "sidenoteDomIdSuffix" 0 }}
-{{ end }}
-{{ .Page.Scratch.Add "sidenoteDomIdSuffix" 1 }}
-{{ $sidenoteDomIdSuffix = .Page.Scratch.Get "sidenoteDomIdSuffix" }}
-<label for="sidenote-{{.Page.UniqueID}}-{{ $sidenoteDomIdSuffix }}" class="margin-toggle sidenote-number"></label>
+{{ $sidenoteDomIdSuffix := .Ordinal }}<label for="sidenote-{{.Page.UniqueID}}-{{ $sidenoteDomIdSuffix }}" class="margin-toggle sidenote-number"></label>
 <input type="checkbox" id="sidenote-{{.Page.UniqueID}}-{{ $sidenoteDomIdSuffix }}" class="margin-toggle"/>
 <span class="sidenote">{{ .Inner }}</span>

--- a/layouts/shortcodes/sidenote.html
+++ b/layouts/shortcodes/sidenote.html
@@ -1,3 +1,9 @@
-<label for="{{ .Get "id" }}" class="margin-toggle sidenote-number"></label>
-<input type="checkbox" id="{{ .Get "id" }}" class="margin-toggle"/>
-<span class="sidenote">{{ .Inner }}</span> 
+{{ $sidenoteDomIdSuffix := .Page.Scratch.Get "sidenoteDomIdSuffix" }}
+{{ if eq $sidenoteDomIdSuffix nil }}
+{{ .Page.Scratch.Set "sidenoteDomIdSuffix" 0 }}
+{{ end }}
+{{ .Page.Scratch.Add "sidenoteDomIdSuffix" 1 }}
+{{ $sidenoteDomIdSuffix = .Page.Scratch.Get "sidenoteDomIdSuffix" }}
+<label for="sidenote-{{.Page.UniqueID}}-{{ $sidenoteDomIdSuffix }}" class="margin-toggle sidenote-number"></label>
+<input type="checkbox" id="sidenote-{{.Page.UniqueID}}-{{ $sidenoteDomIdSuffix }}" class="margin-toggle"/>
+<span class="sidenote">{{ .Inner }}</span>


### PR DESCRIPTION
Prior to this commit, when using the `marginnote` or `sidenote`
shortcodes, you would need to pass a domId parameter to the shortcode.

With this change you no longer need to pass a parameter, and any
parameter passed is ignored. The pre-amble creates a unique domID for
the shortcodes.